### PR TITLE
Atributo type só será retornado se for diferente de Error

### DIFF
--- a/Src/Horse.HandleException.pas
+++ b/Src/Horse.HandleException.pas
@@ -58,7 +58,10 @@ begin
         LJSON.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}('code', {$IF DEFINED(FPC)}TJSONIntegerNumber{$ELSE}TJSONNumber{$ENDIF}.Create(E.Code));
       end;
 
-      LJSON.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}('type', GetEnumName(TypeInfo(TMessageType), Integer(E.&Type)));
+      if E.&Type <> TMessageType.Error then
+      begin
+        LJSON.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}('type', GetEnumName(TypeInfo(TMessageType), Integer(E.&Type)));
+      end;
 
       SendError(Res, LJSON, E.Code);
     end;


### PR DESCRIPTION
Por favor, verifiquem a possibilidade de "type" não ser retornado quando ele não for informado no construtor:
`raise EHorseException.Create('Minha Exception',99); `