### PR TITLE
Algumas mudanças no response do Exception

### DIFF
--- a/Src/Horse.HandleException.pas
+++ b/Src/Horse.HandleException.pas
@@ -69,9 +69,8 @@ begin
     on E: Exception do
     begin
       LJSON := TJSONObject.Create;
-      LJSON.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}('error', E.ClassName);
-      LJSON.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}('description', E.Message);
-      SendError(Res, LJSON, Integer(THTTPStatus.BadRequest));
+      LJSON.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}('error', E.Message);
+      SendError(Res, LJSON, Integer(THTTPStatus.InternalServerError));
     end;
   end;
 end;


### PR DESCRIPTION
1- Atribuir o "E.Message" ao "error", permitirá o uso do mesmo atributo no momento do parse no client;
2- Eliminar E.ClassName. Talvez essa informação não seja de grande valia e esteja apenas "sujando" o JSON de retorno;
3- Será que Status Code 500 não seria mais adequado, já que geralmente a Exception vai ocorrer devido a alguma "falha" no lado do servidor?