### PR TITLE
maintain error status, on exception, when previously informed.

### DIFF
--- a/Src/Horse.HandleException.pas
+++ b/Src/Horse.HandleException.pas
@@ -33,6 +33,7 @@ end;
 procedure HandleException(Req: THorseRequest; Res: THorseResponse; Next: {$IF DEFINED(FPC)}TNextProc{$ELSE}TProc{$ENDIF});
 var
   LJSON: TJSONObject;
+  LStatus: Integer;
 begin
   try
     Next();
@@ -63,9 +64,12 @@ begin
     end;
     on E: Exception do
     begin
+      LStatus := Res.Status;
+      if LStatus < Integer(THTTPStatus.BadRequest) then
+        LStatus := Integer(THTTPStatus.InternalServerError);
       LJSON := TJSONObject.Create;
       LJSON.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}('error', E.Message);
-      SendError(Res, LJSON, Integer(THTTPStatus.InternalServerError));
+      SendError(Res, LJSON, LStatus);
     end;
   end;
 end;


### PR DESCRIPTION
Changed to keep the error code set in case of throwing Exception, currently it forces the 500 code below.

Res.Status(400);
raise Exception.Create('Error');