### PR TITLE
Novo recurso no middleware para interceptar as exceções gerada na API

### DIFF
--- a/src/Horse.HandleException.pas
+++ b/src/Horse.HandleException.pas
@@ -100,7 +100,7 @@ end;
 
 function HandleException: THorseCallback; overload;
 begin
-  Result := Middleware;
+  Result := HandleException(nil);
 end;
 
 function HandleException(const ACallback: TInterceptExceptionCallback): THorseCallback; overload;


### PR DESCRIPTION
Melhoria no middleware Handle-exception para interceptar a exceção gerada na API, podendo logar e manipular a mesma;

Criado o Callback TInterceptExceptionCallback com os parâmetros:

**AException(Exception):** É a classe de exceção gerada na API que pode ser logada e manipulada;
**AResponse(THorseResponse):** É a classe THorseResponse usada para enviar ao cliente uma resposta com a exceção tratada;
**ASendException(Boolean):** Uma variável boolean que é usada internamente no Handle-exception para enviar ou não a mensagem com a exceção;
* True: O Handle-exception envia a mensagem com a exceção; (Default)
* False: É a responsabilidade do desenvolvedor enviar a mensagem ao cliente usando o parâmetro AResponse;

### Verificações

* Quebra de código: Não
* MemoryLeaks: Não
* Hints: Não
* Warnings: Não
* Compatibilidade Delphi: Sim
* Compatibilidade Lazarus: Sim
 * Teste de stress: Sim

### Exemplos

**Exemplo 01:** Handle-exception é o responsável pela notificação pro cliente. (Default)
```delphi
THorse
    .Use(Jhonson)
    .Use(HandleException);

  THorse.Get('/ping',
    procedure(Req: THorseRequest; Res: THorseResponse)
    begin
      raise EHorseException.New
        .Error('My Error!');
    end);
```

**Exemplo 02:** Handle-exception é o responsável pela notificação pro cliente usando o Callback TInterceptExceptionCallback.
```delphi
procedure InterceptException(AException: Exception; AResponse: THorseResponse; var ASendException: Boolean);
var
  lGUID: TGUID;  
  lMessage: string;
begin
  CreateGUID(lGUID);
  lMessage := Format('ID: %s - Message: %s', [GUIDToString(lGUID), AException.Message]);
  
  //LOG DA MENSAGEM
  Writeln(lMessage);
end;

THorse
    .Use(Jhonson)
    .Use(HandleException(InterceptException));

  THorse.Get('/ping',
    procedure(Req: THorseRequest; Res: THorseResponse)
    begin
      raise EHorseException.New
        .Error('My Error!');
    end);
```

**Exemplo 03:** Desenvolvedor é o responsável pela notificação pro cliente usando o Callback TInterceptExceptionCallback..
```delphi
procedure InterceptException(AException: Exception; AResponse: THorseResponse; var ASendException: Boolean);
var
  lGUID: TGUID;  
  lMessage: string;
  lJSON: TJSONObject;
begin
  CreateGUID(lGUID);
  lMessage := Format('ID: %s - Message: %s', [GUIDToString(lGUID), AException.Message]);
  
  //LOG DA MENSAGEM
  Writeln(lMessage);
  
  ASendException := False;
  lJSON := FormatExceptionJSON(AException);
  AResponse.Send<TJSONObject>(lJSON).Status(THTTPStatus.InternalServerError);
end;

THorse
    .Use(Jhonson)
    .Use(HandleException(InterceptException));

  THorse.Get('/ping',
    procedure(Req: THorseRequest; Res: THorseResponse)
    begin
      raise EHorseException.New
        .Error('My Error!');
    end);
```
![image1](https://github.com/HashLoad/handle-exception/assets/20980984/6830346d-d9f3-411b-a941-a9eda91be830)

![image2](https://github.com/HashLoad/handle-exception/assets/20980984/36eb6e1f-05d2-4db0-8765-6d729b10d84a)
